### PR TITLE
Fix Ruby 1.9 lookup issues.

### DIFF
--- a/lib/log_weasel.rb
+++ b/lib/log_weasel.rb
@@ -24,7 +24,7 @@ module LogWeasel
       end
     end
 
-    if defined? Resque
+    if defined? ::Resque
       LogWeasel::Resque.initialize!
     end
 

--- a/lib/log_weasel/railtie.rb
+++ b/lib/log_weasel/railtie.rb
@@ -5,7 +5,7 @@ class LogWeasel::Railtie < Rails::Railtie
 
   initializer "log_weasel.configure" do |app|
     LogWeasel.configure do |config|
-      config.key = app.config.log_weasel[:key] || self.app_name
+      config.key = app.config.log_weasel[:key] || app_name
     end
 
     app.config.middleware.insert_before "::Rails::Rack::Logger", "LogWeasel::Middleware"
@@ -13,7 +13,7 @@ class LogWeasel::Railtie < Rails::Railtie
 
   private
 
-  def self.app_name
+  def app_name
     ::Rails.application.class.to_s.split("::").first
   end
 end


### PR DESCRIPTION
There were two issues I ran into running log_weasel on Ruby 1.9 that were related to class and method lookup. This fixes those problems.
